### PR TITLE
Adding Test Cases for SV32 VM

### DIFF
--- a/riscv-test-suite/rv32i_m/vm_test/src/custom_macros1.h
+++ b/riscv-test-suite/rv32i_m/vm_test/src/custom_macros1.h
@@ -1,0 +1,201 @@
+#include "encoding.h"
+
+#define SATP_SV32_MODE_VAL 0x01
+
+#define SREG sw
+#define LREG lw
+#define MRET mret
+
+#define ENABLE_READ_CHECK     0x01
+#define DISABLE_READ_CHECK    0x00
+#define ENABLE_WRITE_CHECK    0x01
+#define DISABLE_WRITE_CHECK   0x00
+#define ENABLE_EXECUTE_CHECK  0x01
+#define DISBALE_EXECUTE_CHECK 0x00
+
+#define LEVEL0 0x00
+#define LEVEL1 0x01
+
+#define ACCESS_BIT_TEST        0x01
+#define VM_PMP_TEST            0x02
+#define VM_MXR_UNSET_TEST      0x03
+#define VM_SUM_UNSET_TEST      0x04
+#define VM_SATP_SV32_MODE_TEST 0x05
+
+#define REG_CLEAR    0x1
+#define NO_REG_CLEAR 0x0
+
+#define ALL_F_S 0xFFFFFFFF
+#define LHW_F_S 0x0000FFFF
+#define UHW_F_S 0xFFFF0000
+#define B1_F_S  0x000000FF
+#define B2_F_S  0x0000FF00
+#define B3_F_S  0x00FF0000
+#define B4_F_S  0xFF000000
+
+#define PMPADDR0 0x0
+#define PMPADDR1 0x1
+#define PMPADDR2 0x2
+#define PMPADDR3 0x3
+
+#define PMPCFG_0_SHIFT 0x00
+#define PMPCFG_1_SHIFT 0x08
+#define PMPCFG_2_SHIFT 0x10
+#define PMPCFG_3_SHIFT 0x18
+
+#define NAPOT_RANGE_8B  0x0
+#define NAPOT_RANGE_16B 0x01
+#define NAPOT_RANGE_32B 0x03
+
+#define PTE_OFFSET_SHIFT 12
+
+#define INSTRUCTION_ADDRESS_MISALIGNED 0
+#define INSTRUCTION_ACCESS_FAULT       1
+#define ILLEGAL_INSTRUCTION            2 
+#define BREAKPOINT                     3
+#define LOAD_ADDRESS_MISALIGNED        4
+#define LOAD_ACCESS_FAULT              5
+#define STORE_AMO_ADDRESS_MISALIGNED   6
+#define STORE_AMO_ACCESS_FAULT         7
+#define ENVIRONMENT_CALL_FROM_U_MODE   8
+#define ENVIRONMENT_CALL_FROM_S_MODE   9
+#define ENVIRONMENT_CALL_FROM_M_MODE   11
+#define INSTRUCTION_PAGE_FAULT         12
+#define LOAD_PAGE_FAULT                13
+#define STORE_AMO_PAGE_FAULT           15
+
+#define OP_READ    0x0
+#define OP_WRITE   0x1
+#define OP_EXECUTE 0x01
+
+#define ASID_IMPLE_CVA6 0x00400000
+#define EXPECTED_ASID   0x00400000
+
+#define NO_EXCEP_NO     110
+
+#define SHIFT_22         22
+#define SHIFT_20         20
+#define SHIFT_12         12
+#define PGTB_INDEX_SHIFT 2
+
+#define SUCCESS 0
+#define FAILED  1
+
+
+#define WRITE_CSR(CSR_REG, SRC_REG)                                ;\
+    csrw CSR_REG, SRC_REG                                          ;
+
+#define CLEAR_CSR(CSR_REG, SRC_REG)                                ;\
+    csrc CSR_REG, SRC_REG                                          ;
+
+#define SET_CSR(CSR_REG, SRC_REG)                                  ;\
+    csrs CSR_REG, SRC_REG                                          ;
+
+#define READ_CSR(CSR_REG, DST_REG)                                 ;\
+    csrr DST_REG, CSR_REG                                          ;
+
+#define CLEAR_REG(REG)                                             ;\
+    li REG, 0                                                      ;
+
+#define ALL_MEM_PMP                                                ;\
+    li t2, ALL_F_S                                                 ;\
+    csrw pmpaddr0, t2                                              ;\
+    CLEAR_REG(t2)                                                  ;\
+    SET_PMP_TOR_RWX(t2, t6, PMPADDR0)                              ;\
+    csrw pmpcfg0, t2                                               ;\
+
+
+#define SET_PMP_R(REG, TMP, PMPADDR)                               ;\
+    .if(PMPADDR == PMPADDR0)                                       ;\
+        ori REG, REG, PMP_R                                        ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR1)                                       ;\
+        li TMP, PMP_R                                              ;\
+        slli TMP, TMP, PMPADDR1 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR2)                                       ;\
+        li TMP, PMP_R                                              ;\
+        slli TMP, TMP, PMPADDR2 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR3)                                       ;\
+        li TMP, PMP_R                                              ;\
+        slli TMP, TMP, PMPADDR3 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    CLEAR_REG(TMP)                                                 ;
+
+#define SET_PMP_W(REG, TMP, PMPADDR)                               ;\
+    .if(PMPADDR == PMPADDR0)                                       ;\
+        ori REG, REG, PMP_W                                        ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR1)                                       ;\
+        li TMP, PMP_W                                              ;\
+        slli TMP, TMP, PMPADDR1 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR2)                                       ;\
+        li TMP, PMP_W                                              ;\
+        slli TMP, TMP, PMPADDR2 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR3)                                       ;\
+        li TMP, PMP_W                                              ;\
+        slli TMP, TMP, PMPADDR3 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    CLEAR_REG(TMP)                                                 ;
+
+#define SET_PMP_X(REG, TMP, PMPADDR)                               ;\
+    .if(PMPADDR == PMPADDR0)                                       ;\
+        ori REG, REG, PMP_X                                        ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR1)                                       ;\
+        li TMP, PMP_X                                              ;\
+        slli TMP, TMP, PMPADDR1 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR2)                                       ;\
+        li TMP, PMP_X                                              ;\
+        slli TMP, TMP, PMPADDR2 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR3)                                       ;\
+        li TMP, PMP_X                                              ;\
+        slli TMP, TMP, PMPADDR3 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    CLEAR_REG(TMP)                                                 ;
+
+
+#define SET_PMP_TOR(REG, TMP, PMPADDR)                             ;\
+    .if(PMPADDR == PMPADDR0)                                       ;\
+        ori REG, REG, PMP_TOR                                      ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR1)                                       ;\
+        li TMP, PMP_TOR                                            ;\
+        slli TMP, TMP, PMPADDR1 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR2)                                       ;\
+        li TMP, PMP_TOR                                            ;\
+        slli TMP, TMP, PMPADDR2 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    .if(PMPADDR == PMPADDR3)                                       ;\
+        li TMP, PMP_TOR                                            ;\
+        slli TMP, TMP, PMPADDR3 << PMPADDR3                        ;\
+        or REG, REG, TMP                                           ;\
+    .endif                                                         ;\
+    CLEAR_REG(TMP)                                                 ;
+
+
+#define SET_PMP_TOR_RWX(REG, TMP, PMPADDR)                         ;\
+    SET_PMP_X(REG, TMP, PMPADDR)                                   ;\
+    SET_PMP_R(REG, TMP, PMPADDR)                                   ;\
+    SET_PMP_W(REG, TMP, PMPADDR)                                   ;\
+    SET_PMP_TOR(REG, TMP, PMPADDR)                                 ;
+
+
+

--- a/riscv-test-suite/rv32i_m/vm_test/src/vm_satp_access.S
+++ b/riscv-test-suite/rv32i_m/vm_test/src/vm_satp_access.S
@@ -1,0 +1,139 @@
+# ###############################################################################################           
+# Verification Goal: SATP is accessible only in M and S mode not in U mode						#
+#                                                                                               #
+# Description:       Satp is only accessible in M and S mode and illegal instruction          	#
+#                    exception is generated when accessed in lower privilege mode             	#
+# ###############################################################################################   
+
+#include "model_test.h"
+#include "custom_macros1.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sv32)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+  	
+main:
+ # ---------------------------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine								// Verification of existance of rvtest_mtrap_routine
+	LI (a4, 0xceed)
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine								// Verification of existance of rvtest_strap_routine
+	LI (a4, 0xbeed)
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP          								# set the PMP permissions
+	WRITE_CSR (satp,x0)  								# write satp with all zeros (bare mode)
+
+	/* Save Virtual addresses in of Code and Data 
+	in their respective S-mode save area */
+
+	/****** code ******/
+
+	LI (t0, va)
+	LI (t1, pa)
+	sub t0, t0, t1   									# (VA-PA) Note: VA > PA 
+	csrr sp, mscratch
+	add t1,sp,t0
+	csrw sscratch, t1 
+	
+	li s1, ALL_F_S
+    li s2, SATP32_PPN
+    li s3, SATP32_ASID
+ 
+    CLEAR_CSR (satp,s1)
+    SET_CSR   (satp,s2)
+    WRITE_CSR (satp,s3)
+
+	RVTEST_GOTO_LOWER_MODE Smode					    # changes mode from M to S
+
+    CLEAR_CSR (satp,s1)
+    SET_CSR   (satp,s2)
+    WRITE_CSR (satp,s3)
+
+	RVTEST_GOTO_LOWER_MODE Umode						# changes mode from S to U
+
+	CLEAR_CSR (satp,s1)								    # Illegal instruction exception is generated when accessed in U mode 
+    SET_CSR   (satp,s2)
+    WRITE_CSR (satp,s3)
+
+	/******* code *******/
+	/******* code *******/
+	LREG t1, code_bgn_off+0*sv_area_sz(sp)
+	add t2, t1, t0
+	SREG t2, code_bgn_off+1*sv_area_sz(sp)
+
+	/******* data *******/
+	// update save area
+	LREG t1, data_bgn_off+0*sv_area_sz(sp)
+	add  t2, t1,t0
+	SREG t2, data_bgn_off+1*sv_area_sz(sp)
+	//signature
+	LREG t1, sig_bgn_off+0*sv_area_sz(sp)
+	add t2, t1, t0
+	SREG t2, sig_bgn_off+1*sv_area_sz(sp) 
+	
+	
+
+vm_en:
+	RVTEST_GOTO_MMODE								# Switching back to M mode
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)
+mmode:
+	LI (t2, 0xabab)									# Verification if handler is returning and SIGUPD is working afer the handler
+	csrw pmpaddr1, t2								# If in M-mode, this instruction will work otherwise not.
+	csrr a4, pmpaddr1
+	RVTEST_SIGUPD(x13,a4)
+#endif 
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+
+RVTEST_DATA_BEGIN
+.align 12
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP
+#endif
+RVTEST_DATA_END
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END


### PR DESCRIPTION
## [Test for  SATP Access Permission ](https://github.com/10x-Engineers/riscv-arch-test/commit/d780d6c2a0f2f6da568acf69809d871a8e3e7cad)

Please review this test case and the overall implementation to ensure they align with the arch test specifications.This PR introduces a custom macros.h header file also, that is used in this test case and will be used in the other upcoming tests also

Summary:

This pull request adds a test case to verify the access control behavior of the satp (Supervisor Address Translation and Protection) register. The goal of this test is to ensure that the satp register is only accessible in Machine (M) and Supervisor (S) privilege modes, while generating an illegal instruction exception when accessed in lower privilege modes.